### PR TITLE
ci: skip build and auto-release for doc-only changes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 permissions:
   contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - dev
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/workflows/pr-checklist.yml'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Adds `paths-ignore` to `test.yml` so PRs that only touch `.md` or `docs/` files skip the build/vet/test job
- Adds `paths-ignore` to `auto-release.yml` so a doc-only merge to main does not trigger a version bump or new release

## Test plan
- [ ] Merge this to `dev`, then open a PR to `main` that only changes `README.md` — confirm `Build and Test` and `Auto Release` jobs do not run
- [ ] Open a PR with a Go file change — confirm `Build and Test` runs as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)