### PR TITLE
ci: allowlist paths — only build on material code changes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/auto-release.yml'
+      - '.github/workflows/release.yml'
 
 permissions:
   contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,11 @@ on:
     branches:
       - dev
       - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.github/workflows/pr-checklist.yml'
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/test.yml'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
Switches `test.yml` and `auto-release.yml` from `paths-ignore` (exclusion list) to `paths` (allowlist).

**Why allowlist is better:** An exclusion list silently triggers CI on anything not listed — e.g. a new `scripts/` folder or a `Dockerfile` would run CI even if it's doc-adjacent. An allowlist is explicit: only these file types matter for a Go build.

**What triggers CI now:**
| File pattern | test.yml | auto-release.yml |
|---|---|---|
| `**.go` | ✅ | ✅ |
| `go.mod`, `go.sum` | ✅ | ✅ |
| `.github/workflows/test.yml` | ✅ | — |
| `.github/workflows/auto-release.yml` or `release.yml` | — | ✅ |
| `README.md`, `docs/**`, `CHANGELOG.md`, `*.md` | ❌ | ❌ |

**Also supersedes PR #11** on the path-filter logic — recommend merging this into `dev` first, then closing/updating #11.

## Test plan
- [ ] Open a PR that only changes `README.md` — confirm `Build and Test` does not run
- [ ] Open a PR that changes a `.go` file — confirm `Build and Test` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)