### PR TITLE
ci: only release on Go source changes, not workflow file changes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -8,8 +8,6 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
-      - '.github/workflows/auto-release.yml'
-      - '.github/workflows/release.yml'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Removes `.github/workflows/` from `auto-release.yml` paths allowlist.

**The bug:** The previous allowlist included `auto-release.yml` and `release.yml` so that CI changes to those files would self-test. But those files landing on main counted as a "material change" and triggered a version bump — which is wrong. CI workflow changes are not user-facing releases.

**After this fix**, only these file changes on main trigger a release:
- `**.go` — source code
- `go.mod` / `go.sum` — dependency changes

Everything else (docs, CI config, plans, changelogs) is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)